### PR TITLE
Use HTTPS for repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "@hapi/pinpoint",
     "description": "Return the filename and line number of the calling function",
     "version": "2.0.1",
-    "repository": "git://github.com/hapijs/pinpoint",
+    "repository": "https://github.com/hapijs/pinpoint",
     "main": "lib/index.js",
     "types": "lib/index.d.ts",
     "files": [


### PR DESCRIPTION
## Summary
- update the package repository URL to use HTTPS instead of the legacy git protocol

## Validation
- git diff --check
- node -e 'JSON.parse(require("fs").readFileSync("package.json","utf8"))'